### PR TITLE
Fix double preloading guard

### DIFF
--- a/lib/graphql/active_record_batcher/association_loader.rb
+++ b/lib/graphql/active_record_batcher/association_loader.rb
@@ -24,8 +24,7 @@ module GraphQL
         ::ActiveRecord::Associations::Preloader.new.preload(records, association)
 
         records.each do |record|
-          association_result = record.public_send(association)
-          fulfill(record, association_result)
+          fulfill(record, read_association(record))
         end
       end
 
@@ -33,8 +32,12 @@ module GraphQL
 
       attr_reader :model, :association
 
+      def read_association(record)
+        record.public_send(association)
+      end
+
       def association_loaded?(record)
-        record.association(@association).loaded?
+        record.association(association).loaded?
       end
     end
   end

--- a/test/association_loader_test.rb
+++ b/test/association_loader_test.rb
@@ -27,7 +27,17 @@ class FieldInstrumenterTest < Minitest::Test
 
     @loader.perform([shop1, shop2])
 
-    shop1.association(:products).loaded?
-    shop2.association(:products).loaded?
+    assert shop1.association(:products).loaded?
+    assert shop2.association(:products).loaded?
+  end
+
+  def test_not_preloading_twice
+    shop1 = FakeSchema::Data::Shop.first
+    shop2 = FakeSchema::Data::Shop.second
+
+    ::ActiveRecord::Associations::Preloader.new.preload([shop1], :products)
+
+    assert @loader.load(shop1).fulfilled?
+    assert @loader.load(shop2).pending?
   end
 end


### PR DESCRIPTION
I'm was testing the gem. The `AssociationLoader` works great. But there is a call to undefined method `read_association` in `AssociationLoader#load`. This is when you check for already preloaded data.